### PR TITLE
Add 3.13 to python versions dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -64,6 +64,7 @@ body:
        - '3.10'
        - '3.11'
        - '3.12'
+       - '3.13'
     validations:
       required: true
 


### PR DESCRIPTION
Update bug issue template to allow Python 3.13 in dropdown